### PR TITLE
Add citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,7 @@
+cff-version: 1.2.0
+authors:
+- family-names: "Schenkel"
+  given-names: "Torsten"
+title: "Circulatory System Models"
+doi: 10.5281/zenodo.7497881
+url: "https://github.com/TS-CUBED/CirculatorySystemModels.jl"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,3 @@ We believe this library will be useful (dare we say, could be a game changer?) f
 [![Build Status](https://github.com/TS-CUBED/CirculatorySystemModels.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/TS-CUBED/CirculatorySystemModels.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/TS-CUBED/CirculatorySystemModels.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/TS-CUBED/CirculatorySystemModels.jl)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7497881.svg)](https://doi.org/10.5281/zenodo.7497881)
-
-Cite as
-
-Torsten Schenkel. (2023). TS-CUBED/CirculatorySystemModels.jl. Zenodo. https://doi.org/10.5281/zenodo.7497881
-


### PR DESCRIPTION
I added a [citation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) file. GitHub users will see a helper on the repository page with citation file generator.

I also removed the citation note from README. Feel free to re-add it if you prefer that.
