### PR TITLE
subbed D(fun(t)) to Chamber for undefined DE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 /Manifest.toml
 /docs/build/
+.vscode

--- a/src/CirculatorySystemModels.jl
+++ b/src/CirculatorySystemModels.jl
@@ -455,7 +455,7 @@ Named parameters:
                 p ~ in.p
                 p ~ (V - V₀) * E * fun(t)
                 # D(V) ~ in.q + out.q
-                D(p) ~ (in.q + out.q) * E + p / E * DE
+                D(p) ~ (in.q + out.q) * E + p / E * D(fun(t))
         ]
         compose(ODESystem(eqs, t, sts, ps; name=name), in, out)
 end


### PR DESCRIPTION
Addresses issue here: https://github.com/TS-CUBED/CirculatorySystemModels.jl/issues/23

`DE` was undefined in `Chamber`, so using the Differential operator to calculate `DE` from argument `fun`