### PR TITLE
migrate from ModelingToolkit v10 to v11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,6 +45,26 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           files: lcov.info
+  downgrade:
+    name: Downgrade compat - Julia ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      actions: write
+      contents: read
+    strategy:
+      matrix:
+        version:
+          - '1.10'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-downgrade-compat@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,17 @@
 name = "CirculatorySystemModels"
 uuid = "4211d73e-f4e8-40c4-b600-92e4b82f0e1a"
-authors = ["Torsten Schenkel <t.schenkel@shu.ac.uk>, Harry Saxton <harry.saxton@student.shu.ac.uk> and contributors"]
 version = "0.5.0"
+authors = ["Torsten Schenkel <t.schenkel@shu.ac.uk>, Harry Saxton <harry.saxton@student.shu.ac.uk> and contributors"]
 
 [deps]
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
+Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 
 [compat]
 CSV = "0.10"
 DataFrames = "1"
-ModelingToolkit = "10"
+ModelingToolkit = "11"
+Setfield = "1.1.2"
 julia = "1.10"
 
 [extras]

--- a/src/CirculatorySystemModels.jl
+++ b/src/CirculatorySystemModels.jl
@@ -1,67 +1,63 @@
 module CirculatorySystemModels
 
 using ModelingToolkit
+using Setfield
 
 export Pin, OnePort, Ground, Resistor, QResistor, PoiseuilleResistor, Capacitor, Inductance, Compliance, Elastance, VariableElastance, ConstantPressure, ConstantFlow, DrivenPressure, DrivenFlow, DHChamber, ShiChamber, ShiAtrium, ShiHeart, WK3, WK3E, CR, CRL, RRCR, ShiSystemicLoop, ShiPulmonaryLoop, ResistorDiode, OrificeValve, ShiValve, MynardValve_SemiLunar, MynardValve_Atrioventricular
 
 
-@parameters t
+@independent_variables t
 
 D = Differential(t)
 
-@connector Pin begin
-        p(t)
-        q(t), [connect = Flow]
+function Pin(; name)
+        @variables p(t) q(t) [connect = Flow]
+        sys = System(Equation[], t, [p, q], []; name)
+        sys = @set sys.connector_type = ModelingToolkit.connector_type(sys)
+        return sys
 end
 
 
-@mtkmodel Ground begin
-        @components begin
-                g = Pin()
-        end
-        @parameters begin
-                P = 0.0
-        end
-        @equations begin
-                g.p ~ P
-        end
+function Ground(; name, P=0.0)
+        @named g = Pin()
+        ps = @parameters P = P
+        eqs = [g.p ~ P]
+        compose(System(eqs, t, [], ps; name), g)
 end
 
 
-@mtkmodel OnePort begin
-        @components begin
-                out = Pin()
-                in = Pin()
-        end
-        @variables begin
+function OnePort(; name)
+        @named out = Pin()
+        @named in = Pin()
+        sts = @variables begin
                 Δp(t)
                 q(t)
         end
-        @equations begin
+        eqs = [
                 Δp ~ out.p - in.p
                 0 ~ in.q + out.q
                 q ~ in.q
-        end
+        ]
+        compose(System(eqs, t, sts, []; name), in, out)
 end
 
-@mtkmodel OnePortWithExtPressure begin
-        @components begin
-                out = Pin()
-                in = Pin()
-                ep = Pin()
-        end
-        @variables begin
+function OnePortWithExtPressure(; name)
+        @named out = Pin()
+        @named in = Pin()
+        @named ep = Pin()
+        sts = @variables begin
                 Δp(t)
                 q(t)
                 pg(t)
         end
-        @equations begin
+        eqs = [
                 Δp ~ out.p - in.p
                 0 ~ in.q + out.q
                 0 ~ ep.q
                 q ~ in.q
                 pg ~ p - ep.p
-        end
+        ]
+        compose(System(eqs, t, sts, []; name), in, out, ep)
 end
 
 
@@ -79,14 +75,12 @@ Named parameters:
 
 `R`:       Resistance of the vessel to the fluid in mmHg*s/ml
 """
-@mtkmodel Resistor begin
-        @extend OnePort()
-        @parameters begin
-                R = 1.0
-        end
-        @equations begin
-                Δp ~ -q * R
-        end
+function Resistor(; name, R=1.0)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters R = R
+        eqs = [Δp ~ -q * R]
+        extend(System(eqs, t, [], ps; name), oneport)
 end
 
 
@@ -104,14 +98,12 @@ Named parameters:
 
 `K`: non-linear resistance of the vessel to the fluid in mmHg*s^2/ml^2
 """
-@mtkmodel QResistor begin
-        @extend OnePort()
-        @parameters begin
-                K = 1.0
-        end
-        @equations begin
-                Δp ~ -q * abs(q) * K
-        end
+function QResistor(; name, K=1.0)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters K = K
+        eqs = [Δp ~ -q * abs(q) * K]
+        extend(System(eqs, t, [], ps; name), oneport)
 end
 
 
@@ -129,14 +121,12 @@ Named parameters:
 
 `C`:      capacitance of the vessel in ml/mmHg
 """
-@mtkmodel Capacitor begin
-        @extend OnePort()
-        @parameters begin
-                C = 1.0
-        end
-        @equations begin
-                D(Δp) ~ -q / C
-        end
+function Capacitor(; name, C=1.0)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters C = C
+        eqs = [D(Δp) ~ -q / C]
+        extend(System(eqs, t, [], ps; name), oneport)
 end
 
 
@@ -154,14 +144,12 @@ Named parameters:
 
 `L`:       Inertia of the fluid in mmHg*s^2/ml
 """
-@mtkmodel Inductance begin
-        @extend OnePort()
-        @parameters begin
-                L = 1.0
-        end
-        @equations begin
-                D(q) ~ -Δp / L
-        end
+function Inductance(; name, L=1.0)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters L = L
+        eqs = [D(q) ~ -Δp / L]
+        extend(System(eqs, t, [], ps; name), oneport)
 end
 
 
@@ -183,19 +171,13 @@ Named parameters:
 
 `L`:       length of vessel segment in cm
 """
-@mtkmodel PoiseuilleResistor begin
-        @extend OnePort()
-        @parameters begin
-                μ = 3e-2
-                r = 0.1
-                L = 1
-        end
-        begin
-                R = 8 * μ * L / (π * r^4) * (1 / 1333.2)
-        end
-        @equations begin
-                Δp ~ -q * R
-        end
+function PoiseuilleResistor(; name, μ=3e-2, r=0.1, L=1)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters μ = μ r = r L = L
+        R = 8 * μ * L / (π * r^4) * (1 / 1333.2)
+        eqs = [Δp ~ -q * R]
+        extend(System(eqs, t, [], ps; name), oneport)
 end
 
 
@@ -230,7 +212,7 @@ has_variable_ep`: (Bool) expose pin for variable external pressure (default: fal
                    _Note: if `has_variable_ep` is set to `true` this pin is created, independent of
                    `has_ep`!_
 """
-@component function Compliance(; name, V₀=0.0, C=1.0, inP=false, has_ep=false, has_variable_ep=false, p₀=0.0)
+function Compliance(; name, V₀=0.0, C=1.0, inP=false, has_ep=false, has_variable_ep=false, p₀=0.0)
         @named in = Pin()
         @named out = Pin()
 
@@ -329,7 +311,7 @@ has_variable_ep`: (Bool) expose pin for variable external pressure (default: fal
                    _Note: if `has_variable_ep` is set to `true` this pin is created, independent of
                    `has_ep`!_
 """
-@component function Elastance(; name, V₀=0.0, E=1.0, inP=false, has_ep=false, has_variable_ep=false, p₀=0.0)
+function Elastance(; name, V₀=0.0, E=1.0, inP=false, has_ep=false, has_variable_ep=false, p₀=0.0)
         @named in = Pin()
         @named out = Pin()
 
@@ -425,7 +407,7 @@ has_variable_ep`: (Bool) expose pin for variable external pressure (default: fal
                    _Note: if `has_variable_ep` is set to `true` this pin is created, independent of
                    `has_ep`!_
 """
-@component function VariableElastance(; name, V₀=0.0, C=1.0, Escale=1.0, fun, inP=false, has_ep=false, has_variable_ep=false, p₀=0.0)
+function VariableElastance(; name, V₀=0.0, C=1.0, Escale=1.0, fun, inP=false, has_ep=false, has_variable_ep=false, p₀=0.0)
         @named in = Pin()
         @named out = Pin()
 
@@ -502,14 +484,12 @@ Named parameters:
 
 `P`:     Constant pressure in mmHg
 """
-@mtkmodel ConstantPressure begin
-        @extend OnePort()
-        @parameters begin
-                P = 1.0
-        end
-        @equations begin
-                Δp ~ P
-        end
+function ConstantPressure(; name, P=1.0)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters P = P
+        eqs = [Δp ~ P]
+        extend(System(eqs, t, [], ps; name), oneport)
 end
 
 
@@ -527,14 +507,12 @@ Named parameters:
 
 `Q`:     Constant flow in cm^3/s (ml/s)
 """
-@mtkmodel ConstantFlow begin
-        @extend OnePort()
-        @parameters begin
-                Q = 1.0
-        end
-        @equations begin
-                q ~ Q
-        end
+function ConstantFlow(; name, Q=1.0)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters Q = Q
+        eqs = [q ~ Q]
+        extend(System(eqs, t, [], ps; name), oneport)
 end
 
 
@@ -554,17 +532,12 @@ Named parameters:
 
 `fun`:   Function which modulates the input
 """
-@mtkmodel DrivenPressure begin
-        @extend OnePort()
-        @structural_parameters begin
-                fun = sin
-        end
-        @parameters begin
-                P = 1.0
-        end
-        @equations begin
-                Δp ~ P * fun(t)
-        end
+function DrivenPressure(; name, fun=sin, P=1.0)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters P = P
+        eqs = [Δp ~ P * fun(t)]
+        extend(System(eqs, t, [], ps; name), oneport)
 end
 
 """
@@ -585,18 +558,12 @@ Named parameters:
 
 `fun`:   Function which modulates the input
 """
-@mtkmodel DrivenFlow begin
-        @extend OnePort()
-        @structural_parameters begin
-                fun = sin
-        end
-        @parameters begin
-
-                Q = 1.0
-        end
-        @equations begin
-                q ~ Q * fun(t)
-        end
+function DrivenFlow(; name, fun=sin, Q=1.0)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters Q = Q
+        eqs = [q ~ Q * fun(t)]
+        extend(System(eqs, t, [], ps; name), oneport)
 end
 
 """
@@ -649,49 +616,49 @@ Named parameters:
 to 1/max(e(t)), which ensures that e(t) varies between zero and 1.0, such that
 E(t) varies between Eₘᵢₙ and Eₘₐₓ.
 """
-@mtkmodel DHChamber begin
-        @components begin
-                in = Pin()
-                out = Pin()
-        end
-        @structural_parameters begin
-                inP = false
-        end
-        @variables begin
+function DHChamber(; name, V₀, p₀=0.0, Eₘᵢₙ, Eₘₐₓ, n₁, n₂, τ, τ₁, τ₂, k, Eshift=0.0, inP=false)
+        @named in = Pin()
+        @named out = Pin()
+        sts = @variables begin
                 V(t)
                 p(t)
         end
-        @parameters begin
-                V₀
-                p₀ = 0.0
-                Eₘᵢₙ
-                Eₘₐₓ
-                n₁
-                n₂
-                τ
-                τ₁
-                τ₂
-                k
-                Eshift = 0.0
+        ps = @parameters begin
+                V₀ = V₀
+                p₀ = p₀
+                Eₘᵢₙ = Eₘᵢₙ
+                Eₘₐₓ = Eₘₐₓ
+                n₁ = n₁
+                n₂ = n₂
+                τ = τ
+                τ₁ = τ₁
+                τ₂ = τ₂
+                k = k
+                Eshift = Eshift
         end
 
-        begin
-                E = DHelastance(t, Eₘᵢₙ, Eₘₐₓ, n₁, n₂, τ, τ₁, τ₂, Eshift, k)
-                DE = DHdelastance(t, Eₘᵢₙ, Eₘₐₓ, n₁, n₂, τ, τ₁, τ₂, Eshift, k)
-                p_rel = p₀
-        end
+        E = DHelastance(t, Eₘᵢₙ, Eₘₐₓ, n₁, n₂, τ, τ₁, τ₂, Eshift, k)
+        DE = DHdelastance(t, Eₘᵢₙ, Eₘₐₓ, n₁, n₂, τ, τ₁, τ₂, Eshift, k)
+        p_rel = p₀
 
-        @equations begin
+        eqs = [
                 0 ~ in.p - out.p
                 p ~ in.p
-                if inP
-                        V ~ (p - p_rel) / E + V₀
+        ]
+
+        if inP
+                push!(eqs,
+                        V ~ (p - p_rel) / E + V₀,
                         D(p) ~ (in.q + out.q) * E + (p - p_rel) / E * DE
-                else
-                        p ~ (V - V₀) * E + p_rel
+                )
+        else
+                push!(eqs,
+                        p ~ (V - V₀) * E + p_rel,
                         D(V) ~ in.q + out.q
-                end
+                )
         end
+
+        compose(System(eqs, t, sts, ps; name), in, out)
 end
 
 
@@ -753,47 +720,46 @@ Named parameters:
 
 `inP`:    (Bool) formulate in dp/dt (default: false)
 """
-@mtkmodel ShiChamber begin
-        @structural_parameters begin
-                inP = false
-        end
-        @variables begin
+function ShiChamber(; name, V₀, p₀=0.0, Eₘᵢₙ, Eₘₐₓ, τ, τₑₛ, τₑₚ, Eshift, inP=false)
+        @named in = Pin()
+        @named out = Pin()
+        sts = @variables begin
                 V(t)
                 p(t)
         end
-        @parameters begin
-                V₀
-                p₀ = 0.0
-                Eₘᵢₙ
-                Eₘₐₓ
-                τ
-                τₑₛ
-                τₑₚ
-                Eshift
+        ps = @parameters begin
+                V₀ = V₀
+                p₀ = p₀
+                Eₘᵢₙ = Eₘᵢₙ
+                Eₘₐₓ = Eₘₐₓ
+                τ = τ
+                τₑₛ = τₑₛ
+                τₑₚ = τₑₚ
+                Eshift = Eshift
         end
 
-        @components begin
-                in = Pin()
-                out = Pin()
-        end
-        begin
-                E = ShiElastance(t, Eₘᵢₙ, Eₘₐₓ, τ, τₑₛ, τₑₚ, Eshift)
-                DE = DShiElastance(t, Eₘᵢₙ, Eₘₐₓ, τ, τₑₛ, τₑₚ, Eshift)
-                p_rel = p₀
-        end
+        E = ShiElastance(t, Eₘᵢₙ, Eₘₐₓ, τ, τₑₛ, τₑₚ, Eshift)
+        DE = DShiElastance(t, Eₘᵢₙ, Eₘₐₓ, τ, τₑₛ, τₑₚ, Eshift)
+        p_rel = p₀
 
-        @equations begin
+        eqs = [
                 0 ~ in.p - out.p
                 p ~ in.p
-                if inP
+        ]
 
-                        V ~ (p - p_rel) / E + V₀
+        if inP
+                push!(eqs,
+                        V ~ (p - p_rel) / E + V₀,
                         D(p) ~ (in.q + out.q) * E + (p - p_rel) / E * DE
-                else
-                        p ~ (V - V₀) * E + p_rel
+                )
+        else
+                push!(eqs,
+                        p ~ (V - V₀) * E + p_rel,
                         D(V) ~ in.q + out.q
-                end
+                )
         end
+
+        compose(System(eqs, t, sts, ps; name), in, out)
 end
 
 
@@ -885,49 +851,47 @@ name    name of the element
 
 `τpww`  Atrial offset time in s
 """
-@mtkmodel ShiAtrium begin
-        @components begin
-                in = Pin()
-                out = Pin()
-        end
-        @variables begin
+function ShiAtrium(; name, V₀, p₀, Eₘᵢₙ, Eₘₐₓ, τ, τpwb, τpww, inP=false)
+        @named in = Pin()
+        @named out = Pin()
+        sts = @variables begin
                 V(t)
                 p(t)
         end
-        @structural_parameters begin
-                inP = false
-        end
-        @parameters begin
-                V₀
-                p₀
-                Eₘᵢₙ
-                Eₘₐₓ
-                τ
-                τpwb
-                τpww
+        ps = @parameters begin
+                V₀ = V₀
+                p₀ = p₀
+                Eₘᵢₙ = Eₘᵢₙ
+                Eₘₐₓ = Eₘₐₓ
+                τ = τ
+                τpwb = τpwb
+                τpww = τpww
         end
 
-        begin
-                # adjust timing parameters to fit the elastance functions for the ventricle
-                # define elastance based on ventricle E function
-                E = ShiElastance(t, Eₘᵢₙ, Eₘₐₓ, τ, 0.5 * τpww, τpww, τpwb)
-                DE = DShiElastance(t, Eₘᵢₙ, Eₘₐₓ, τ, 0.5 * τpww, τpww, τpwb)
-                p_rel = p₀
-        end
+        # adjust timing parameters to fit the elastance functions for the ventricle
+        # define elastance based on ventricle E function
+        E = ShiElastance(t, Eₘᵢₙ, Eₘₐₓ, τ, 0.5 * τpww, τpww, τpwb)
+        DE = DShiElastance(t, Eₘᵢₙ, Eₘₐₓ, τ, 0.5 * τpww, τpww, τpwb)
+        p_rel = p₀
 
-        @equations begin
+        eqs = [
                 0 ~ in.p - out.p
                 p ~ in.p
+        ]
 
-                if inP
-                        V ~ (p - p_rel) / E + V₀
+        if inP
+                push!(eqs,
+                        V ~ (p - p_rel) / E + V₀,
                         D(p) ~ (in.q + out.q) * E + (p - p_rel) / E * DE
-                else
-                        p ~ (V - V₀) * E + p_rel
+                )
+        else
+                push!(eqs,
+                        p ~ (V - V₀) * E + p_rel,
                         D(V) ~ in.q + out.q
-                end
+                )
         end
 
+        compose(System(eqs, t, sts, ps; name), in, out)
 end
 
 
@@ -1065,41 +1029,38 @@ Named parameters:
 
 `TV_θmin`   Tricuspid valve minimum opening angle in rad
 """
-@mtkmodel ShiHeart begin
-        @structural_parameters begin
-                τ
-        end
-        @components begin
-                LHin = Pin()
-                LHout = Pin()
-                RHin = Pin()
-                RHout = Pin()
-                in = Pin()
-                out = Pin()
-        end
-        @variables begin
+function ShiHeart(; name, τ,
+                LV_V₀, LV_p₀=0.0, LV_Eₘᵢₙ, LV_Eₘₐₓ, LV_τ, LV_τₑₛ, LV_τₑₚ, LV_Eshift=0.0,
+                RV_V₀, RV_p₀=0.0, RV_Eₘᵢₙ, RV_Eₘₐₓ, RV_τ, RV_τₑₛ, RV_τₑₚ, RV_Eshift=0.0,
+                LA_V₀, LA_p₀=0.0, LA_Eₘᵢₙ, LA_Eₘₐₓ, LA_τ, LA_τₑₛ, LA_τₑₚ, LA_Eshift=0.0,
+                RA_V₀, RA_p₀=0.0, RA_Eₘᵢₙ, RA_Eₘₐₓ, RA_τ, RA_τₑₛ, RA_τₑₚ, RA_Eshift=0.0,
+                AV_CQ, AV_Kp, AV_Kf, AV_Kb, AV_Kv, AV_θmax, AV_θmin,
+                MV_CQ, MV_Kp, MV_Kf, MV_Kb, MV_Kv, MV_θmax, MV_θmin,
+                TV_CQ, TV_Kp, TV_Kf, TV_Kb, TV_Kv, TV_θmax, TV_θmin,
+                PV_CQ, PV_Kp, PV_Kf, PV_Kb, PV_Kv, PV_θmax, PV_θmin)
+        @named LHin = Pin()
+        @named LHout = Pin()
+        @named RHin = Pin()
+        @named RHout = Pin()
+        @named in = Pin()
+        @named out = Pin()
+        sts = @variables begin
                 Δp(t)
                 q(t)
         end
-        # sts = []
-        # ps = @parameters Rc=Rc Rp=Rp C=C
-        # No parameters in this function
-        # Parameters are inherited from subcomponents
 
-        @components begin
-                # These are the components the subsystem is made of:
-                # Ventricles and atria
-                LV = ShiChamber(V₀, p₀, Eₘᵢₙ, Eₘₐₓ, τ, τₑₛ, τₑₚ, Eshift)
-                RV = ShiChamber(V₀, p₀, Eₘᵢₙ, Eₘₐₓ, τ, τₑₛ, τₑₚ, Eshift)
-                LA = ShiChamber(V₀, p₀, Eₘᵢₙ, Eₘₐₓ, τ, τₑₛ, τₑₚ, Eshift)
-                RA = ShiChamber(V₀, p₀, Eₘᵢₙ, Eₘₐₓ, τ, τₑₛ, τₑₚ, Eshift)
-                # Valves
-                AV = ShiValve(CQ, Kp, Kf, Kb, Kv, θmax, θmin)
-                MV = ShiValve(CQ, Kp, Kf, Kb, Kv, θmax, θmin)
-                TV = ShiValve(CQ, Kp, Kf, Kb, Kv, θmax, θmin)
-                PV = ShiValve(CQ, Kp, Kf, Kb, Kv, θmax, θmin)
-        end
-        @equations begin
+        # Ventricles and atria
+        @named LV = ShiChamber(V₀=LV_V₀, p₀=LV_p₀, Eₘᵢₙ=LV_Eₘᵢₙ, Eₘₐₓ=LV_Eₘₐₓ, τ=LV_τ, τₑₛ=LV_τₑₛ, τₑₚ=LV_τₑₚ, Eshift=LV_Eshift)
+        @named RV = ShiChamber(V₀=RV_V₀, p₀=RV_p₀, Eₘᵢₙ=RV_Eₘᵢₙ, Eₘₐₓ=RV_Eₘₐₓ, τ=RV_τ, τₑₛ=RV_τₑₛ, τₑₚ=RV_τₑₚ, Eshift=RV_Eshift)
+        @named LA = ShiChamber(V₀=LA_V₀, p₀=LA_p₀, Eₘᵢₙ=LA_Eₘᵢₙ, Eₘₐₓ=LA_Eₘₐₓ, τ=LA_τ, τₑₛ=LA_τₑₛ, τₑₚ=LA_τₑₚ, Eshift=LA_Eshift)
+        @named RA = ShiChamber(V₀=RA_V₀, p₀=RA_p₀, Eₘᵢₙ=RA_Eₘᵢₙ, Eₘₐₓ=RA_Eₘₐₓ, τ=RA_τ, τₑₛ=RA_τₑₛ, τₑₚ=RA_τₑₚ, Eshift=RA_Eshift)
+        # Valves
+        @named AV = ShiValve(CQ=AV_CQ, Kp=AV_Kp, Kf=AV_Kf, Kb=AV_Kb, Kv=AV_Kv, θmax=AV_θmax, θmin=AV_θmin)
+        @named MV = ShiValve(CQ=MV_CQ, Kp=MV_Kp, Kf=MV_Kf, Kb=MV_Kb, Kv=MV_Kv, θmax=MV_θmax, θmin=MV_θmin)
+        @named TV = ShiValve(CQ=TV_CQ, Kp=TV_Kp, Kf=TV_Kf, Kb=TV_Kb, Kv=TV_Kv, θmax=TV_θmax, θmin=TV_θmin)
+        @named PV = ShiValve(CQ=PV_CQ, Kp=PV_Kp, Kf=PV_Kf, Kb=PV_Kb, Kv=PV_Kv, θmax=PV_θmax, θmin=PV_θmin)
+
+        eqs = [
                 Δp ~ out.p - in.p
                 q ~ in.q
                 connect(LHin, LA.in)
@@ -1112,7 +1073,9 @@ Named parameters:
                 connect(TV.out, RV.in)
                 connect(RV.out, PV.in)
                 connect(PV.out, RHout)
-        end
+        ]
+
+        compose(System(eqs, t, sts, []; name), LHin, LHout, RHin, RHout, in, out, LV, RV, LA, RA, AV, MV, TV, PV)
 end
 
 
@@ -1129,14 +1092,12 @@ Named parameters:
 
 `R`     Resistance across the valve in mmHg*s/ml
 """
-@mtkmodel ResistorDiode begin
-        @extend OnePort()
-        @parameters begin
-                R = 1e-3
-        end
-        @equations begin
-                q ~ -Δp / R * (Δp < 0)
-        end
+function ResistorDiode(; name, R=1e-3)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters R = R
+        eqs = [q ~ -Δp / R * (Δp < 0)]
+        extend(System(eqs, t, [], ps; name), oneport)
 end
 
 
@@ -1153,14 +1114,12 @@ Named parameters:
 
 `CQ`    Flow coefficent in ml/(s*mmHg^0.5)
 """
-@mtkmodel OrificeValve begin
-        @extend OnePort()
-        @parameters begin
-                CQ = 1.0
-        end
-        @equations begin
-                q ~ (Δp < 0) * CQ * sqrt(sign(Δp) * Δp)
-        end
+function OrificeValve(; name, CQ=1.0)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters CQ = CQ
+        eqs = [q ~ (Δp < 0) * CQ * sqrt(sign(Δp) * Δp)]
+        extend(System(eqs, t, [], ps; name), oneport)
 end
 
 
@@ -1190,7 +1149,7 @@ Named parameters:
 
 `θmin`  Valve minimum opening angle in rad
 """
-@component function ShiValve(; name, CQ, Kp, Kf, Kb, Kv, θmax, θmin)
+function ShiValve(; name, CQ, Kp, Kf, Kb, Kv, θmax, θmin)
         @named oneport = OnePort()
         @unpack Δp, q = oneport
         ps = @parameters CQ = CQ Kp = Kp Kf = Kf Kb = Kb Kv = Kv θmax = θmax θmin = θmin
@@ -1262,18 +1221,11 @@ name    name of the element
 p is calculated in mmHg
 q is calculated in cm^3/s (ml/s)
 """
-@mtkmodel MynardValve_SemiLunar begin
-        @extend OnePort()
-        @parameters begin
-                ρ
-                Leff
-                Mrg
-                Mst
-                Ann
-                Kvc
-                Kvo
-        end
-        @variables begin
+function MynardValve_SemiLunar(; name, ρ, Leff, Mrg, Mst, Ann, Kvc, Kvo)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters ρ = ρ Leff = Leff Mrg = Mrg Mst = Mst Ann = Ann Kvc = Kvc Kvo = Kvo
+        sts = @variables begin
                 Aeff(t)
                 ζ(t)
                 B(t)
@@ -1281,10 +1233,8 @@ q is calculated in cm^3/s (ml/s)
                 Aeff_max(t)
                 L(t)
         end
-        begin
-                Δp = -1333.22 * Δp
-        end
-        @equations begin
+        Δp = -1333.22 * Δp
+        eqs = [
                 # Opening ratio
                 D(ζ) ~ (Δp > 0) * ((1 - ζ) * Kvo * Δp) + (Δp < 0) * (ζ * Kvc * Δp)
                 Aeff_min ~ Mrg * Ann + eps()
@@ -1294,7 +1244,8 @@ q is calculated in cm^3/s (ml/s)
                 B ~ ρ / (2 * Aeff^2)
                 L ~ ρ * Leff / Aeff
                 D(q) ~ (Δp - B * q * abs(q)) * 1 / L
-        end
+        ]
+        extend(System(eqs, t, sts, ps; name), oneport)
 end
 
 
@@ -1324,17 +1275,11 @@ name    name of the element
 p is calculated in mmHg
 q is calculated in cm^3/s (ml/s)
 """
-@mtkmodel MynardValve_Atrioventricular begin
-        @extend OnePort()
-        @parameters begin
-                ρ
-                Mrg
-                Mst
-                Ann
-                Kvc
-                Kvo
-        end
-        @variables begin
+function MynardValve_Atrioventricular(; name, ρ, Mrg, Mst, Ann, Kvc, Kvo)
+        @named oneport = OnePort()
+        @unpack Δp, q = oneport
+        ps = @parameters ρ = ρ Mrg = Mrg Mst = Mst Ann = Ann Kvc = Kvc Kvo = Kvo
+        sts = @variables begin
                 Aeff(t)
                 ζ(t)
                 B(t)
@@ -1342,10 +1287,8 @@ q is calculated in cm^3/s (ml/s)
                 Aeff_max(t)
                 L(t)
         end
-        begin
-                p = -1333.22 * p
-        end
-        @equations begin
+        p = -1333.22 * p
+        eqs = [
                 # Opening ratio
                 D(ζ) ~ (Δp > 0) * ((1 - ζ) * Kvo * Δp) + (Δp < 0) * (ζ * Kvc * Δp)
                 Aeff_min ~ Mrg * Ann + eps()
@@ -1354,7 +1297,8 @@ q is calculated in cm^3/s (ml/s)
                 # Flow equation
                 B ~ ρ / (2 * Aeff^2)
                 q ~ sqrt(1 / B * abs(Δp)) * sign(Δp)
-        end
+        ]
+        extend(System(eqs, t, sts, ps; name), oneport)
 end
 
 
@@ -1376,20 +1320,18 @@ Named parameters:
 
 `C`:       Arterial compliance in ml/mmHg
 """
-@mtkmodel WK3 begin
-        @extend OnePort()
-        @components begin
-                Rc = Resistor(R=1.0)
-                Rp = Resistor(R=1.0)
-                C = Capacitor(C=1.0)
-                ground = Ground()
-        end
-
-        @equations begin
-                connect(in, Rc.in)
+function WK3(; name)
+        @named oneport = OnePort()
+        @named Rc = Resistor(R=1.0)
+        @named Rp = Resistor(R=1.0)
+        @named C = Capacitor(C=1.0)
+        @named ground = Ground()
+        eqs = [
+                connect(oneport.in, Rc.in)
                 connect(Rc.out, Rp.in, C.in)
-                connect(Rp.out, C.out, out)
-        end
+                connect(Rp.out, C.out, oneport.out)
+        ]
+        extend(compose(System(eqs, t, [], []; name), Rc, Rp, C, ground), oneport)
 end
 
 
@@ -1411,21 +1353,19 @@ Named parameters:
 
 `E`:       Arterial elastance in mmHg/ml
 """
-@mtkmodel WK3E begin
-        @extend OnePort()
-        @components begin
-                Rc = Resistor(R=1.0)
-                Rp = Resistor(R=1.0)
-                E = Elastance(E=1.0)
-                ground = Ground()
-        end
-
-        @equations begin
-                connect(in, Rc.in)
+function WK3E(; name)
+        @named oneport = OnePort()
+        @named Rc = Resistor(R=1.0)
+        @named Rp = Resistor(R=1.0)
+        @named E = Elastance(E=1.0)
+        @named ground = Ground()
+        eqs = [
+                connect(oneport.in, Rc.in)
                 connect(Rc.out, E.in)
                 connect(E.out, Rp.in)
-                connect(Rp.out, out)
-        end
+                connect(Rp.out, oneport.out)
+        ]
+        extend(compose(System(eqs, t, [], []; name), Rc, Rp, E, ground), oneport)
 end
 
 
@@ -1449,25 +1389,20 @@ Named parameters:
 
 `C`:       Arterial compliance in ml/mmHg
 """
-@mtkmodel WK4_S begin
-        @extend OnePort()
-
-        @components begin
-                # These are the components the subsystem is made of:
-                Rc = Resistor(R)
-                Rp = Resistor(R)
-                C = Capacitor(C)
-                L = Inductance(L)
-                ground = Ground()
-        end
-        # The equations for the subsystem are created by
-        # 'connect'-ing the components
-        @equations begin
-                connect(in, Rc.in)
+function WK4_S(; name)
+        @named oneport = OnePort()
+        @named Rc = Resistor(R=1.0)
+        @named Rp = Resistor(R=1.0)
+        @named C = Capacitor(C=1.0)
+        @named L = Inductance(L=1.0)
+        @named ground = Ground()
+        eqs = [
+                connect(oneport.in, Rc.in)
                 connect(Rc.out, L.in)
                 connect(L.out, C.in, Rp.in)
-                connect(Rp.out, C.out, out)
-        end
+                connect(Rp.out, C.out, oneport.out)
+        ]
+        extend(compose(System(eqs, t, [], []; name), Rc, Rp, C, L, ground), oneport)
 end
 
 
@@ -1492,27 +1427,21 @@ Named parameters:
 
 `E`:       Arterial elastance in mmHg/ml
 """
-@mtkmodel WK4_SE begin
-        @extend OnePort()
-
-        @components begin
-                # These are the components the subsystem is made of:
-                Rc = Resistor(R)
-                Rp = Resistor(R)
-                E = Elastance(E)
-                L = Inductance(L)
-                ground = Ground()
-        end
-
-        # The equations for the subsystem are created by
-        # 'connect'-ing the components
-        @equations begin
-                connect(in, Rc.in)
+function WK4_SE(; name)
+        @named oneport = OnePort()
+        @named Rc = Resistor(R=1.0)
+        @named Rp = Resistor(R=1.0)
+        @named E = Elastance(E=1.0)
+        @named L = Inductance(L=1.0)
+        @named ground = Ground()
+        eqs = [
+                connect(oneport.in, Rc.in)
                 connect(Rc.out, L.in)
                 connect(L.out, E.in)
                 connect(E.out, Rp.in)
-                connect(Rp.out, out)
-        end
+                connect(Rp.out, oneport.out)
+        ]
+        extend(compose(System(eqs, t, [], []; name), Rc, Rp, E, L, ground), oneport)
 end
 
 
@@ -1536,23 +1465,19 @@ Named parameters:
 
 `C`:       Arterial compliance in ml/mmHg
 """
-@mtkmodel WK4_P begin
-        @extend OnePort()
-        @components begin
-                Rc = Resistor(R=1.0)
-                Rp = Resistor(R=1.0)
-                C = Capacitor(C=1.0)
-                L = Inductance(L=1.0)
-                ground = Ground()
-        end
-
-        # The equations for the subsystem are created by
-        # 'connect'-ing the components
-        @equations begin
-                connect(in, L.in, Rc.in)
+function WK4_P(; name)
+        @named oneport = OnePort()
+        @named Rc = Resistor(R=1.0)
+        @named Rp = Resistor(R=1.0)
+        @named C = Capacitor(C=1.0)
+        @named L = Inductance(L=1.0)
+        @named ground = Ground()
+        eqs = [
+                connect(oneport.in, L.in, Rc.in)
                 connect(L.out, Rc.out, C.in, Rp.in)
-                connect(Rp.out, C.out, out)
-        end
+                connect(Rp.out, C.out, oneport.out)
+        ]
+        extend(compose(System(eqs, t, [], []; name), Rc, Rp, C, L, ground), oneport)
 end
 
 
@@ -1577,68 +1502,60 @@ Named parameters:
 
 `E`:       Arterial elastance in mmHg/ml
 """
-@mtkmodel WK4_PE begin
-        @extend OnePort()
-
-        @components begin
-                Rc = Resistor(R=1.0)
-                Rp = Resistor(R=1.0)
-                E = Elastance(E=1.0)
-                L = Inductance(L=1.0)
-                ground = Ground()
-        end
-
-        @equations begin
-                connect(in, L.in, Rc.in)
+function WK4_PE(; name)
+        @named oneport = OnePort()
+        @named Rc = Resistor(R=1.0)
+        @named Rp = Resistor(R=1.0)
+        @named E = Elastance(E=1.0)
+        @named L = Inductance(L=1.0)
+        @named ground = Ground()
+        eqs = [
+                connect(oneport.in, L.in, Rc.in)
                 connect(L.out, Rc.out, E.in)
                 connect(E.out, Rp.in)
-                connect(Rp.out, out)
-        end
+                connect(Rp.out, oneport.out)
+        ]
+        extend(compose(System(eqs, t, [], []; name), Rc, Rp, E, L, ground), oneport)
 end
 
 
-@mtkmodel WK5 begin
-        @extend OnePort()
-        @components begin
-                R1 = Resistor(R=1.0)
-                C1 = Capacitor(C=1.0)
-                R2 = Resistor(R=1.0)
-                C2 = Capacitor(C=1.0)
-                R3 = Resistor(R=1.0)
-                L = Inductance(L=1.0)
-                ground = Ground()
-        end
-
-        @equations begin
-                connect(in, R1.in)
+function WK5(; name)
+        @named oneport = OnePort()
+        @named R1 = Resistor(R=1.0)
+        @named C1 = Capacitor(C=1.0)
+        @named R2 = Resistor(R=1.0)
+        @named C2 = Capacitor(C=1.0)
+        @named R3 = Resistor(R=1.0)
+        @named L = Inductance(L=1.0)
+        @named ground = Ground()
+        eqs = [
+                connect(oneport.in, R1.in)
                 connect(R1.out, C1.in, R2.in)
                 connect(R2.out, C2.in, R3.in)
-                connect(R3.out, C1.out, C2.out, out)
-        end
+                connect(R3.out, C1.out, C2.out, oneport.out)
+        ]
+        extend(compose(System(eqs, t, [], []; name), R1, C1, R2, C2, R3, L, ground), oneport)
 end
 
 
-@mtkmodel WK5E begin
-        @extend OnePort()
-
-        @components begin
-                R1 = Resistor(R=1.0)
-                E1 = Elastance(E=1.0)
-                R2 = Resistor(R=1.0)
-                E2 = Elastance(E=1.0)
-                R3 = Resistor(R=1.0)
-                L = Inductance(L=1.0)
-                ground = Ground()
-        end
-
-        @equations begin
-                connect(in, R1.in)
+function WK5E(; name)
+        @named oneport = OnePort()
+        @named R1 = Resistor(R=1.0)
+        @named E1 = Elastance(E=1.0)
+        @named R2 = Resistor(R=1.0)
+        @named E2 = Elastance(E=1.0)
+        @named R3 = Resistor(R=1.0)
+        @named L = Inductance(L=1.0)
+        @named ground = Ground()
+        eqs = [
+                connect(oneport.in, R1.in)
                 connect(R1.out, E1.in)
                 connect(E1.out, R2.in)
                 connect(R2.out, E2.in)
                 connect(E2.out, R3.in)
-                connect(R3.out, out)
-        end
+                connect(R3.out, oneport.out)
+        ]
+        extend(compose(System(eqs, t, [], []; name), R1, E1, R2, E2, R3, L, ground), oneport)
 end
 
 
@@ -1658,28 +1575,23 @@ Named parameters:
 
 `C`:       Component compliance in ml/mmHg
 """
-@mtkmodel CR begin
-        @structural_parameters begin
-                R=1.0
-                C=1.0
-        end
-        @variables begin
+function CR(; name, R=1.0, C=1.0)
+        @named in = Pin()
+        @named out = Pin()
+        @named R = Resistor(R=R)
+        @named C = Compliance(C=C)
+        sts = @variables begin
                 Δp(t)
                 q(t)
         end
-        @components begin
-                in = Pin()
-                out = Pin()
-                R = Resistor(R=R)
-                C = Compliance(C=C)
-        end
-        @equations begin
+        eqs = [
                 Δp ~ out.p - in.p
                 q ~ in.q
                 connect(in, C.in)
                 connect(C.out, R.in)
                 connect(R.out, out)
-        end
+        ]
+        compose(System(eqs, t, sts, []; name), in, out, R, C)
 end
 
 
@@ -1701,31 +1613,25 @@ Named parameters:
 
 `L`:       Component blood inertia in mmHg*s^2/ml
 """
-@mtkmodel CRL begin
-        @structural_parameters begin
-                C=1.0
-                R=1.0
-                L=1.0
-        end
-        @variables begin
+function CRL(; name, C=1.0, R=1.0, L=1.0)
+        @named in = Pin()
+        @named out = Pin()
+        @named C = Compliance(C=C)
+        @named R = Resistor(R=R)
+        @named L = Inductance(L=L)
+        sts = @variables begin
                 Δp(t)
                 q(t)
         end
-        @components begin
-                in = Pin()
-                out = Pin()
-                C = Compliance(C=C)
-                R = Resistor(R=R)
-                L = Inductance(L=L)
-        end
-        @equations begin
+        eqs = [
                 Δp ~ out.p - in.p
                 q ~ in.q
                 connect(in, C.in)
                 connect(C.out, R.in)
                 connect(R.out, L.in)
                 connect(L.out, out)
-        end
+        ]
+        compose(System(eqs, t, sts, []; name), in, out, C, R, L)
 end
 
 
@@ -1749,24 +1655,19 @@ Named parameters:
 
 `R3`:      Component resistance in mmHg*s/ml
 """
-@mtkmodel RRCR begin
-
-        @variables begin
+function RRCR(; name)
+        @named in = Pin()
+        @named out = Pin()
+        @named ep = Pin()
+        @named R1 = Resistor(R=1.0)
+        @named R2 = Resistor(R=1.0)
+        @named C = Compliance(C=1.0)
+        @named R3 = Resistor(R=1.0)
+        sts = @variables begin
                 p(t)
                 q(t)
         end
-
-        @components begin
-                in = Pin()
-                out = Pin()
-                ep = Pin()
-                R1 = Resistor(R)
-                R2 = Resistor(R)
-                C = Compliance_ep(C)
-                R3 = Resistor(R)
-        end
-
-        @equations begin
+        eqs = [
                 p ~ out.p - in.p
                 q ~ in.q
                 connect(in, R1.in)
@@ -1775,7 +1676,8 @@ Named parameters:
                 connect(C.out, R3.in)
                 connect(R3.out, out)
                 connect(C.ep, ep)
-        end
+        ]
+        compose(System(eqs, t, sts, []; name), in, out, ep, R1, R2, C, R3)
 end
 
 
@@ -1811,28 +1713,29 @@ Named parameters:
 
 `SVN_R`:   Vein resistance in mmHg*s/ml
 """
-@mtkmodel ShiSystemicLoop begin
-        @variables begin
+function ShiSystemicLoop(; name,
+                SAS_C=1.0, SAS_R=1.0, SAS_L=1.0,
+                SAT_C=1.0, SAT_R=1.0, SAT_L=1.0,
+                SAR_R=1.0, SCP_R=1.0,
+                SVN_C=1.0, SVN_R=1.0)
+        @named in = Pin()
+        @named out = Pin()
+        # These are the components the subsystem is made of:
+        ## Systemic Aortic Sinus ##
+        @named SAS = CRL(C=SAS_C, R=SAS_R, L=SAS_L)
+        ## Systemic Artery ##
+        @named SAT = CRL(C=SAT_C, R=SAT_R, L=SAT_L)
+        ## Systemic Arteriole ##
+        @named SAR = Resistor(R=SAR_R)
+        ## Systemic Capillary ##
+        @named SCP = Resistor(R=SCP_R)
+        ## Systemic Vein ##
+        @named SVN = CR(C=SVN_C, R=SVN_R)
+        sts = @variables begin
                 Δp(t)
                 q(t)
         end
-        @components begin
-                in = Pin()
-                out = Pin()
-                # These are the components the subsystem is made of:
-                ## Systemic Aortic Sinus ##
-                SAS = CRL(C, R, L)
-                ## Systemic Artery ##
-                SAT = CRL(C, R, L)
-                ## Systemic Arteriole ##
-                SAR = Resistor(R)
-                ## Systemic Capillary ##
-                SCP = Resistor(R)
-                ## Systemic Vein ##
-                SVN = CR(C, R)
-        end
-
-        @equations begin
+        eqs = [
                 Δp ~ out.p - in.p
                 q ~ in.q
                 connect(in, SAS.in)
@@ -1841,7 +1744,8 @@ Named parameters:
                 connect(SAR.out, SCP.in)
                 connect(SCP.out, SVN.in)
                 connect(SVN.out, out)
-        end
+        ]
+        compose(System(eqs, t, sts, []; name), in, out, SAS, SAT, SAR, SCP, SVN)
 end
 
 
@@ -1877,29 +1781,29 @@ Named parameters:
 
 `PVN__R`:   Vein resistance in mmHg*s/ml
 """
-@mtkmodel ShiPulmonaryLoop begin
-        @variables begin
+function ShiPulmonaryLoop(; name,
+                PAS_C=1.0, PAS_R=1.0, PAS_L=1.0,
+                PAT_C=1.0, PAT_R=1.0, PAT_L=1.0,
+                PAR_R=1.0, PCP_R=1.0,
+                PVN_C=1.0, PVN_R=1.0)
+        @named in = Pin()
+        @named out = Pin()
+        # These are the components the subsystem is made of:
+        ## Pulmonary Aortic Sinus ##
+        @named PAS = CRL(C=PAS_C, R=PAS_R, L=PAS_L)
+        ## Pulmonary Artery ##
+        @named PAT = CRL(C=PAT_C, R=PAT_R, L=PAT_L)
+        ## Pulmonary Arteriole ##
+        @named PAR = Resistor(R=PAR_R)
+        ## Pulmonary Capillary ##
+        @named PCP = Resistor(R=PCP_R)
+        ## Pulmonary Vein ##
+        @named PVN = CR(C=PVN_C, R=PVN_R)
+        sts = @variables begin
                 Δp(t)
                 q(t)
         end
-
-        @components begin
-                in = Pin()
-                out = Pin()
-                # These are the components the subsystem is made of:
-                ## Pulmonary Aortic Sinus ##
-                PAS = CRL(C, R, L)
-                ## Pulmonary Artery ##
-                PAT = CRL(C, R, L)
-                ## Pulmonary Arteriole ##
-                PAR = Resistor(R)
-                ## Pulmonary Capillary ##
-                PCP = Resistor(R)
-                ## Pulmonary Vein ##
-                PVN = CR(C, R)
-        end
-
-        @equations begin
+        eqs = [
                 Δp ~ out.p - in.p
                 q ~ in.q
                 connect(in, PAS.in)
@@ -1908,8 +1812,8 @@ Named parameters:
                 connect(PAR.out, PCP.in)
                 connect(PCP.out, PVN.in)
                 connect(PVN.out, out)
-        end
-
+        ]
+        compose(System(eqs, t, sts, []; name), in, out, PAS, PAT, PAR, PCP, PVN)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -246,60 +246,59 @@ end
     @independent_variables t
 
     ## Shi Heart (with AV stenosis: max AV opening angle = 40 degrees!)
-    @mtkmodel CirculatoryModel begin
-        @components begin
-            heart = ShiHeart(τ=τ,
-                LV.V₀=v0_lv, LV.p₀=p0_lv, LV.Eₘᵢₙ=Emin_lv, LV.Eₘₐₓ=Emax_lv, LV.τ=τ, LV.τₑₛ=τes_lv, LV.τₑₚ=τed_lv, LV.Eshift=0.0,
-                RV.V₀=v0_rv, RV.p₀=p0_rv, RV.Eₘᵢₙ=Emin_rv, RV.Eₘₐₓ=Emax_rv, RV.τ=τ, RV.τₑₛ=τes_rv, RV.τₑₚ=τed_rv, RV.Eshift=0.0,
-                LA.V₀=v0_la, LA.p₀=p0_la, LA.Eₘᵢₙ=Emin_la, LA.Eₘₐₓ=Emax_la, LA.τ=τ, LA.τₑₛ=τpww_la / 2, LA.τₑₚ=τpww_la, LA.Eshift=τpwb_la,
-                RA.V₀=v0_ra, RA.p₀=p0_ra, RA.Eₘᵢₙ=Emin_ra, RA.Eₘₐₓ=Emax_ra, RA.τ=τ, RA.τₑₛ=τpww_ra / 2, RA.τₑₚ=τpww_ra, RA.Eshift=τpwb_ra,
-                AV.CQ=CQ_AV, AV.Kp=Kp_av, AV.Kf=Kf_av, AV.Kb=0.0, AV.Kv=3.5, AV.θmax=40.0 * pi / 180, AV.θmin=5.0 * pi / 180,
-                MV.CQ=CQ_MV, MV.Kp=Kp_mv, MV.Kf=Kf_mv, MV.Kb=0.0, MV.Kv=3.5, MV.θmax=75.0 * pi / 180, MV.θmin=5.0 * pi / 180,
-                TV.CQ=CQ_TV, TV.Kp=Kp_tv, TV.Kf=Kf_tv, TV.Kb=0.0, TV.Kv=3.5, TV.θmax=75.0 * pi / 180, TV.θmin=5.0 * pi / 180,
-                PV.CQ=CQ_PV, PV.Kp=Kp_pv, PV.Kf=Kf_pv, PV.Kb=0.0, PV.Kv=3.5, PV.θmax=75.0 * pi / 180, PV.θmin=5.0 * pi / 180
-            )
-            syst_loop = ShiSystemicLoop(SAS.C=Csas, SAS.R=Rsas, SAS.L=Lsas,
-                SAT.C=Csat, SAT.R=Rsat, SAT.L=Lsat,
-                SAR.R=Rsar, SCP.R=Rscp, SVN.C=Csvn, SVN.R=Rsvn
-            )
-            pulm_loop = ShiPulmonaryLoop(PAS.C=Cpas, PAS.R=Rpas, PAS.L=Lpas,
-                PAT.C=Cpat, PAT.R=Rpat, PAT.L=Lpat,
-                PAR.R=Rpar, PCP.R=Rpcp, PVN.C=Cpvn, PVN.R=Rpvn
-            )
-        end
-        @equations begin
-            connect(heart.LHout, syst_loop.in)
-            connect(syst_loop.out, heart.RHin)
-            connect(heart.RHout, pulm_loop.in)
-            connect(pulm_loop.out, heart.LHin)
-        end
-    end
+    @named heart = ShiHeart(τ=τ,
+        LV_V₀=v0_lv, LV_p₀=p0_lv, LV_Eₘᵢₙ=Emin_lv, LV_Eₘₐₓ=Emax_lv, LV_τ=τ, LV_τₑₛ=τes_lv, LV_τₑₚ=τed_lv, LV_Eshift=0.0,
+        RV_V₀=v0_rv, RV_p₀=p0_rv, RV_Eₘᵢₙ=Emin_rv, RV_Eₘₐₓ=Emax_rv, RV_τ=τ, RV_τₑₛ=τes_rv, RV_τₑₚ=τed_rv, RV_Eshift=0.0,
+        LA_V₀=v0_la, LA_p₀=p0_la, LA_Eₘᵢₙ=Emin_la, LA_Eₘₐₓ=Emax_la, LA_τ=τ, LA_τₑₛ=τpww_la / 2, LA_τₑₚ=τpww_la, LA_Eshift=τpwb_la,
+        RA_V₀=v0_ra, RA_p₀=p0_ra, RA_Eₘᵢₙ=Emin_ra, RA_Eₘₐₓ=Emax_ra, RA_τ=τ, RA_τₑₛ=τpww_ra / 2, RA_τₑₚ=τpww_ra, RA_Eshift=τpwb_ra,
+        AV_CQ=CQ_AV, AV_Kp=Kp_av, AV_Kf=Kf_av, AV_Kb=0.0, AV_Kv=3.5, AV_θmax=40.0 * pi / 180, AV_θmin=5.0 * pi / 180,
+        MV_CQ=CQ_MV, MV_Kp=Kp_mv, MV_Kf=Kf_mv, MV_Kb=0.0, MV_Kv=3.5, MV_θmax=75.0 * pi / 180, MV_θmin=5.0 * pi / 180,
+        TV_CQ=CQ_TV, TV_Kp=Kp_tv, TV_Kf=Kf_tv, TV_Kb=0.0, TV_Kv=3.5, TV_θmax=75.0 * pi / 180, TV_θmin=5.0 * pi / 180,
+        PV_CQ=CQ_PV, PV_Kp=Kp_pv, PV_Kf=Kf_pv, PV_Kb=0.0, PV_Kv=3.5, PV_θmax=75.0 * pi / 180, PV_θmin=5.0 * pi / 180
+    )
+    @named syst_loop = ShiSystemicLoop(SAS_C=Csas, SAS_R=Rsas, SAS_L=Lsas,
+        SAT_C=Csat, SAT_R=Rsat, SAT_L=Lsat,
+        SAR_R=Rsar, SCP_R=Rscp, SVN_C=Csvn, SVN_R=Rsvn
+    )
+    @named pulm_loop = ShiPulmonaryLoop(PAS_C=Cpas, PAS_R=Rpas, PAS_L=Lpas,
+        PAT_C=Cpat, PAT_R=Rpat, PAT_L=Lpat,
+        PAR_R=Rpar, PCP_R=Rpcp, PVN_C=Cpvn, PVN_R=Rpvn
+    )
 
-    @mtkcompile circ_sys = CirculatoryModel()
+    circ_eqs = [
+        connect(heart.LHout, syst_loop.in)
+        connect(syst_loop.out, heart.RHin)
+        connect(heart.RHout, pulm_loop.in)
+        connect(pulm_loop.out, heart.LHin)
+    ]
+
+    @named _circ_model = System(circ_eqs, t)
+    @named circ_model = compose(_circ_model, [heart, syst_loop, pulm_loop])
+    circ_sys = mtkcompile(circ_model)
 
     u0 = [
-        circ_sys.heart.LV.V => LV_Vt0
-        circ_sys.heart.RV.V => RV_Vt0
-        circ_sys.heart.LA.V => LA_Vt0
-        circ_sys.heart.RA.V => RA_Vt0
-        circ_sys.heart.AV.θ => 5.0 * pi / 180 + 0.01
-        circ_sys.heart.AV.ω => 0
-        circ_sys.heart.MV.θ => 5.0 * pi / 180 + 0.01
-        circ_sys.heart.MV.ω => 0
-        circ_sys.heart.TV.θ => 5.0 * pi / 180 + 0.01
-        circ_sys.heart.TV.ω => 0
-        circ_sys.heart.PV.θ => 5.0 * pi / 180 + 0.01
-        circ_sys.heart.PV.ω => 0
-        circ_sys.syst_loop.SAS.C.p => pt0sas
-        circ_sys.syst_loop.SAS.L.q => qt0sas
-        circ_sys.syst_loop.SAT.C.p => pt0sat
-        circ_sys.syst_loop.SAT.L.q => qt0sat
-        circ_sys.syst_loop.SVN.C.p => pt0svn
-        circ_sys.pulm_loop.PAS.C.p => pt0pas
-        circ_sys.pulm_loop.PAS.L.q => qt0pas
-        circ_sys.pulm_loop.PAT.C.p => pt0pat
-        circ_sys.pulm_loop.PAT.L.q => qt0pat
-        circ_sys.pulm_loop.PVN.C.p => pt0pvn
+        heart.LV.V => LV_Vt0
+        heart.RV.V => RV_Vt0
+        heart.LA.V => LA_Vt0
+        heart.RA.V => RA_Vt0
+        heart.AV.θ => 5.0 * pi / 180 + 0.01
+        heart.AV.ω => 0
+        heart.MV.θ => 5.0 * pi / 180 + 0.01
+        heart.MV.ω => 0
+        heart.TV.θ => 5.0 * pi / 180 + 0.01
+        heart.TV.ω => 0
+        heart.PV.θ => 5.0 * pi / 180 + 0.01
+        heart.PV.ω => 0
+        syst_loop.SAS.C.p => pt0sas
+        syst_loop.SAS.L.q => qt0sas
+        syst_loop.SAT.C.p => pt0sat
+        syst_loop.SAT.L.q => qt0sat
+        syst_loop.SVN.C.p => pt0svn
+        pulm_loop.PAS.C.p => pt0pas
+        pulm_loop.PAS.L.q => qt0pas
+        pulm_loop.PAT.C.p => pt0pat
+        pulm_loop.PAT.L.q => qt0pat
+        pulm_loop.PVN.C.p => pt0pvn
     ]
 
     prob = ODEProblem(circ_sys, u0, (0.0, 20.0))
@@ -313,10 +312,10 @@ end
     ShiBench = CSV.read("ShiComplex.csv", DataFrame)
 
     @test SciMLBase.successful_retcode(ShiComplexSol)
-    @test sum((ShiComplexSolInt[circ_sys.heart.LV.V] .- ShiBench[!, :LV_V]) ./ ShiBench[!, :LV_V]) / length(ShiComplexSolInt.u) ≈ 0 atol = 1e-3
-    @test sum((ShiComplexSolInt[circ_sys.heart.RV.V] .- ShiBench[!, :RV_V]) ./ ShiBench[!, :RV_V]) / length(ShiComplexSolInt.u) ≈ 0 atol = 1e-3
-    @test sum((ShiComplexSolInt[circ_sys.heart.LA.V] .- ShiBench[!, :LA_V]) ./ ShiBench[!, :LA_V]) / length(ShiComplexSolInt.u) ≈ 0 atol = 1e-3
-    @test sum((ShiComplexSolInt[circ_sys.heart.RA.V] .- ShiBench[!, :RA_V]) ./ ShiBench[!, :RA_V]) / length(ShiComplexSolInt.u) ≈ 0 atol = 1e-3
+    @test sum((ShiComplexSolInt[heart.LV.V] .- ShiBench[!, :LV_V]) ./ ShiBench[!, :LV_V]) / length(ShiComplexSolInt.u) ≈ 0 atol = 1e-3
+    @test sum((ShiComplexSolInt[heart.RV.V] .- ShiBench[!, :RV_V]) ./ ShiBench[!, :RV_V]) / length(ShiComplexSolInt.u) ≈ 0 atol = 1e-3
+    @test sum((ShiComplexSolInt[heart.LA.V] .- ShiBench[!, :LA_V]) ./ ShiBench[!, :LA_V]) / length(ShiComplexSolInt.u) ≈ 0 atol = 1e-3
+    @test sum((ShiComplexSolInt[heart.RA.V] .- ShiBench[!, :RA_V]) ./ ShiBench[!, :RA_V]) / length(ShiComplexSolInt.u) ≈ 0 atol = 1e-3
     ##
 end
 


### PR DESCRIPTION
- Replace all `@mtkmodel` blocks with plain Julia functions using `System()`, `extend()`, and `compose()`
- Convert `@connector Pin` to function-based definition using `Setfield`. This is how its done in their tutorials now as weird as that seems.
- Replace `@parameters t` with `@independent_variables t`
- remove `@component` prefixes
- convert `@structural_parameters` to regular keyword arguments